### PR TITLE
Generating the cache key with the endpoint, client_id and client_secret

### DIFF
--- a/djalf/managers.py
+++ b/djalf/managers.py
@@ -9,6 +9,10 @@ log = logging.getLogger(__name__)
 
 class TokenManagerDjango(TokenManager):
 
+    def _get_cache_key(self):
+        return '{}_{}_{}'.format(self._token_endpoint, self._client_id,
+                                 self._client_secret)
+
     def _get_from_cache(self):
         return cache.get(self._token_endpoint)
 

--- a/djalf/managers.py
+++ b/djalf/managers.py
@@ -14,7 +14,7 @@ class TokenManagerDjango(TokenManager):
                                  self._client_secret)
 
     def _get_from_cache(self):
-        return cache.get(self._token_endpoint)
+        return cache.get(self._get_cache_key())
 
     def _validate_cached_data(self, token_data):
         if token_data:
@@ -41,5 +41,5 @@ class TokenManagerDjango(TokenManager):
         log.info('Getting a new token')
         token_data = super(TokenManagerDjango, self)._request_token()
         token_data['expires_on'] = datetime.now() + timedelta(seconds=token_data.get('expires_in', 0))
-        cache.set(self._token_endpoint, token_data, token_data.get('expires_in', 0))
+        cache.set(self._get_cache_key(), token_data, token_data.get('expires_in', 0))
         return token_data

--- a/tests/managers/test_django_manager.py
+++ b/tests/managers/test_django_manager.py
@@ -25,7 +25,7 @@ class TestTokenManagerDjango(TestCase):
 
     def setUp(self):
         self.token = Token(access_token='anoldtoken',
-                           expires_in=self.token_data.get('expires_in'))
+                           expires_on=self.token_data.get('expires_in'))
 
         self.manager._token = self.token
 

--- a/tests/managers/test_django_manager.py
+++ b/tests/managers/test_django_manager.py
@@ -23,6 +23,10 @@ class TestTokenManagerDjango(TestCase):
             'http://endpoint/token', 'client_id', 'client_secret'
         )
 
+        cls.cache_key = '{}_{}_{}'.format(cls.manager._token_endpoint,
+                                          cls.manager._client_id,
+                                          cls.manager._client_secret)
+
     def setUp(self):
         self.token = Token(access_token='anoldtoken',
                            expires_on=self.token_data.get('expires_in'))
@@ -57,8 +61,7 @@ class TestTokenManagerDjango(TestCase):
     @patch('djalf.managers.cache.get')
     def test_get_from_cache_should_returns_data_stored_in_cache(self, cache_get):
         self.manager._get_from_cache()
-
-        cache_get.assert_called_once_with(self.manager._token_endpoint)
+        cache_get.assert_called_once_with(self.cache_key)
 
     @patch('alf.managers.TokenManager._request_token')
     @patch('djalf.managers.cache.set')
@@ -69,7 +72,7 @@ class TestTokenManagerDjango(TestCase):
 
         self.manager._request_token()
 
-        cache_set.assert_called_once_with(self.manager._token_endpoint, token_data, 10)
+        cache_set.assert_called_once_with(self.cache_key, token_data, 10)
 
     @freeze_time(DEFAULT_DATE_TIME_STR)
     @patch('alf.managers.TokenManager._request_token')
@@ -84,7 +87,7 @@ class TestTokenManagerDjango(TestCase):
 
         self.assertEqual(token_data.get('expires_on'), expected_expires_on)
 
-        cache_set.assert_called_once_with(self.manager._token_endpoint, token_data, 10)
+        cache_set.assert_called_once_with(self.cache_key, token_data, 10)
 
     @patch('djalf.managers.log.info')
     @patch('alf.managers.TokenManager._request_token')

--- a/tests/managers/test_django_manager.py
+++ b/tests/managers/test_django_manager.py
@@ -144,3 +144,8 @@ class TestTokenManagerDjango(TestCase):
         self.manager.reset_token()
 
         log_warning.assert_called_once_with('Starting token reset process')
+
+    def test_cache_key_should_be_formed_by_endpoint_client_id_and_secret(self):
+        cache_key = self.manager._get_cache_key()
+        self.assertEqual(cache_key,
+                         'http://endpoint/token_client_id_client_secret')


### PR DESCRIPTION
Fix tests
Generating the cache key with the endpoint, client_id and client_secret
